### PR TITLE
Memory-safety bug fixes and kernel build fix

### DIFF
--- a/acpi_call.c
+++ b/acpi_call.c
@@ -184,7 +184,8 @@ static char *parse_acpi_args(char *input, int *nargs, union acpi_object **args)
                 while (*s && *s++ != '"')
                     arg->string.length ++;
                 // skip the last "
-                ++s;
+                if (*s == '"')
+                    ++s;
             } else if (*s == 'b') {
                 // decode buffer - bXXXX
                 char *p = ++s;

--- a/acpi_call.c
+++ b/acpi_call.c
@@ -56,7 +56,7 @@ static int acpi_result_to_string(union acpi_object *result) {
         // just 4 chars, but there is also two bytes from the curly brackets
         int show_values = min((size_t)result->buffer.length, get_avail_bytes() / 6);
 
-        sprintf(get_buffer_end(), "{");
+        snprintf(get_buffer_end(), get_avail_bytes(), "{");
         for (i = 0; i < show_values; i++)
             sprintf(get_buffer_end(),
                 i == 0 ? "0x%02x" : ", 0x%02x", result->buffer.pointer[i]);
@@ -72,7 +72,7 @@ static int acpi_result_to_string(union acpi_object *result) {
         }
     } else if (result->type == ACPI_TYPE_PACKAGE) {
         int i;
-        sprintf(get_buffer_end(), "[");
+        snprintf(get_buffer_end(), get_avail_bytes(), "[");
         for (i=0; i<result->package.count; i++) {
             if (i > 0)
                 snprintf(get_buffer_end(), get_avail_bytes(), ", ");

--- a/acpi_call.c
+++ b/acpi_call.c
@@ -168,6 +168,10 @@ static char *parse_acpi_args(char *input, int *nargs, union acpi_object **args)
         return input;
 
     *args = (union acpi_object *) kmalloc(MAX_ACPI_ARGS * sizeof(union acpi_object), GFP_KERNEL);
+    if (!*args) {
+        printk(KERN_ERR "acpi_call: unable to allocate buffer\n");
+        return NULL;
+    }
 
     while (*s) {
         if (*s == ' ') {
@@ -205,6 +209,11 @@ static char *parse_acpi_args(char *input, int *nargs, union acpi_object **args)
                 len /= 2;
 
                 buf = (u8*) kmalloc(len, GFP_KERNEL);
+                if (!buf) {
+                    printk(KERN_ERR "acpi_call: unable to allocate buffer\n");
+                    --*nargs;
+                    goto err;
+                }
                 for (i=0; i<len; i++) {
                     buf[i] = decodeHex(s + i*2);
                 }
@@ -241,6 +250,11 @@ static char *parse_acpi_args(char *input, int *nargs, union acpi_object **args)
                 }
                 // store the result in new allocated buffer
                 buf = (u8*) kmalloc(arg->buffer.length, GFP_KERNEL);
+                if (!buf) {
+                    printk(KERN_ERR "acpi_call: unable to allocate buffer\n");
+                    --*nargs;
+                    goto err;
+                }
                 memcpy(buf, temporary_buffer, arg->buffer.length);
                 arg->buffer.pointer = buf;
             } else {

--- a/acpi_call.c
+++ b/acpi_call.c
@@ -1,12 +1,16 @@
 /* Copyright (c) 2010: Michal Kottman */
 
-#include <linux/acpi.h>
 #include <linux/module.h>
 #include <linux/kernel.h>
 #include <linux/version.h>
 #include <linux/proc_fs.h>
 #include <linux/slab.h>
 #include <asm/uaccess.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 17, 0)
+#include <linux/acpi.h>
+#else
+#include <acpi/acpi.h>
+#endif
 
 MODULE_LICENSE("GPL");
 


### PR DESCRIPTION
This pull request does a couple of things:

* Allows building the same source code against kernel versions both before and after 3.17, eliminating the need for a separate branch for older kernel versions.
* Fixes a handful of memory safety bugs in corner cases -- memory leaks, accesses past the ends of buffers, and unhandled memory allocation failures.  I doubt any of these can be used for much mischief, since you'd have to be root anyway to write to /proc/acpi/call, but it's probably good to have these fixed nonetheless.

Tested against kernels 4.1 and (Debian jessie) 3.16 on a ThinkPad T440p (thanks for tpacpi-bat!).