### PR TITLE
fix build for 5.6* kernels

### DIFF
--- a/acpi_call.c
+++ b/acpi_call.c
@@ -348,11 +348,18 @@ static ssize_t acpi_proc_read( struct file *filp, char __user *buff,
     return ret;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
+static struct proc_ops proc_acpi_operations = {
+	.proc_read = acpi_proc_read,
+	.proc_write = acpi_proc_write,
+};
+#else
 static struct file_operations proc_acpi_operations = {
         .owner    = THIS_MODULE,
         .read     = acpi_proc_read,
         .write    = acpi_proc_write,
 };
+#endif
 
 #else
 static int acpi_proc_read(char *page, char **start, off_t off,

--- a/acpi_call.c
+++ b/acpi_call.c
@@ -348,7 +348,7 @@ static ssize_t acpi_proc_read( struct file *filp, char __user *buff,
     return ret;
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
 static struct proc_ops proc_acpi_operations = {
 	.proc_read = acpi_proc_read,
 	.proc_write = acpi_proc_write,


### PR DESCRIPTION
this will make a module work in new kernels
i use it with xmm2usb script to enable modem in x1 carbon gen7