### PR TITLE
Add RPM specs for acpi_call-kmod(-common)

### DIFF
--- a/acpi_call-kmod-common.spec
+++ b/acpi_call-kmod-common.spec
@@ -1,0 +1,32 @@
+%if 0%{?fedora}
+%global debug_package %{nil}
+%endif
+
+Name:     acpi_call-kmod-common
+Version:  100.{{{ git_dir_version }}}
+Release:  1%{?dist}
+Summary:  acpi_call module common package
+License:  GPLv3
+URL:      https://github.com/cr7pt0gt4ph7/acpi_call
+
+VCS:      {{{ git_dir_vcs }}}
+Source:   {{{ git_dir_pack }}}
+
+# A small lie
+Provides: acpi_call-kernel-modules-dkms = %{version}
+Requires: acpi_call-kmod >= %{version}
+
+BuildRequires: systemd-rpm-macros
+
+%description
+acpi_call kernel module common package
+
+%prep
+{{{ git_dir_setup_macro }}}
+
+%files
+%doc README.md
+%license LICENSE
+
+%changelog
+{{{ git_dir_changelog }}}

--- a/acpi_call-kmod.spec
+++ b/acpi_call-kmod.spec
@@ -1,0 +1,54 @@
+%if 0%{?fedora}
+%global buildforkernels akmod
+%global debug_package %{nil}
+%endif
+
+Name:     acpi_call-kmod
+Version:  100.{{{ git_dir_version }}}
+Release:  1%{?dist}
+Summary:  acpi_call module
+License:  GPLv3
+URL:      https://github.com/cr7pt0gt4ph7/acpi_call
+
+VCS:      {{{ git_dir_vcs }}}
+Source:   {{{ git_dir_pack }}}
+
+BuildRequires: kmodtool
+
+%{expand:%(kmodtool --target %{_target_cpu} --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
+
+%description
+acpi_call kernel module
+
+%prep
+# error out if there was something wrong with kmodtool
+%{?kmodtool_check}
+
+# print kmodtool output for debugging purposes:
+kmodtool --target %{_target_cpu} --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null
+
+{{{ git_dir_setup_macro }}}
+
+find . -type f -name '*.c' -exec sed -i "s/#VERSION#/%{version}/" {} \+
+
+for kernel_version  in %{?kernel_versions} ; do
+  mkdir -p _kmod_build_${kernel_version%%___*}
+  cp -a *.c _kmod_build_${kernel_version%%___*}/
+  cp -a Makefile _kmod_build_${kernel_version%%___*}/
+done
+
+%build
+for kernel_version  in %{?kernel_versions} ; do
+  make V=1 %{?_smp_mflags} -C ${kernel_version##*___} M=${PWD}/_kmod_build_${kernel_version%%___*} VERSION=v%{version} modules
+done
+
+%install
+for kernel_version in %{?kernel_versions}; do
+ mkdir -p %{buildroot}%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+ install -D -m 755 _kmod_build_${kernel_version%%___*}/acpi_call.ko %{buildroot}%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+ chmod a+x %{buildroot}%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/acpi_call.ko
+done
+%{?akmod_install}
+
+%changelog
+{{{ git_dir_changelog }}}


### PR DESCRIPTION
Adds the Fedora RPM specs for publishing `acpi_call` as an akmod package (basically Fedora's alternative to DKMS).

- Example builds of the RPM can be found here:
  https://copr.fedorainfracloud.org/coprs/cr7pt0gr4ph7/acpi_call/

- Actual installation (and thus compilation) of the RPM can be found here[^1]:
  https://github.com/cr7pt0gr4ph7/akmods/actions

The intent is to contribute both the RPM build and the pre-built image creation to https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/ and https://github.com/ublue-os/akmods, respectively, so that other users of [Bluefin](https://projectbluefin.io/) can benefit from it, too. Please kindly refer to ublue-os/akmods#327 for the corresponding PR.

[^1]: Note: The failure of the coreos 42 builds is not caused by `acpi_call`, but by there not yet being a suitable kernel version being published in the Fedora upstream; the build failure is also present in the [`ublue-os/akmods` upstream repository](https://github.com/ublue-os/akmods/actions).